### PR TITLE
Removing Orlando from the site

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -215,15 +215,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col col-xs-6 col-sm-6 col-md-4">
-                            <div class="team-image">
-                                <img src="%PUBLIC_URL%/images/team/orlando-lamerez.png" />
-                                <div class="team-overlay">
-                                    <div class="name">Orlando<br/>Lamerez</div>
-                                    <div class="title">Sr. Front-end Developer</div>
-                                </div>
-                            </div>
-                        </div>
                     </div>
                 </div>
                 <div class="six columns">

--- a/public/index.html
+++ b/public/index.html
@@ -325,15 +325,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col col-xs-6 col-sm-6 col-md-4">
-                            <div class="team-image">
-                                <img src="%PUBLIC_URL%/images/team/orlando-lamerez.png" />
-                                <div class="team-overlay">
-                                    <div class="name">Orlando<br/>Lamerez</div>
-                                    <div class="title">Sr. Front-end Developer</div>
-                                </div>
-                            </div>
-                        </div>
                     </div>
                 </div>
                 <div class="six columns">


### PR DESCRIPTION
Simply removes markup that promoted Orlando.